### PR TITLE
Display workspace label in browser tab

### DIFF
--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import AboutComponent from '@/components/landing/AboutComponent.vue';
+import { onMounted } from 'vue';
+
+onMounted(() => {
+  // Update tab name
+  document.title = 'About - Ownly';
+})
 </script>
 
 <template>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -5,7 +5,7 @@ import { onMounted } from 'vue';
 onMounted(() => {
   // Update tab name
   document.title = 'About - Ownly';
-})
+});
 </script>
 
 <template>

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -78,6 +78,9 @@ async function refreshList() {
 }
 
 onMounted(async () => {
+  // Update tab name
+  document.title = "Dashboard - Ownly"
+
   await refreshList();
 
   if (route.name === 'join') {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -79,7 +79,7 @@ async function refreshList() {
 
 onMounted(async () => {
   // Update tab name
-  document.title = "Dashboard - Ownly"
+  document.title = 'Dashboard - Ownly';
 
   await refreshList();
 

--- a/src/views/SpaceHomeView.vue
+++ b/src/views/SpaceHomeView.vue
@@ -54,7 +54,7 @@ async function setup() {
   if (!wksp.value) return;
 
   // Update tab name
-  document.title = wksp.value.metadata.label + ' - Ownly'
+  document.title = wksp.value.metadata.label + ' - Ownly';
 
   if (wksp.value.metadata.pendingSetup) {
     showWelcome.value = true;

--- a/src/views/SpaceHomeView.vue
+++ b/src/views/SpaceHomeView.vue
@@ -53,6 +53,9 @@ async function setup() {
   wksp.value = await Workspace.setupOrRedir(router);
   if (!wksp.value) return;
 
+  // Update tab name
+  document.title = wksp.value.metadata.label + ' - Ownly'
+
   if (wksp.value.metadata.pendingSetup) {
     showWelcome.value = true;
 


### PR DESCRIPTION
- In dashboard, browser tab now shows `Dashboard - Ownly`
- In about page, browser tab now shows `About - Ownly`
- In workspace, browser tab now shows `{wksp.value.metadata.label} - Ownly`

resolves #61 