### PR TITLE
Fix browser tab not changing when entering through deep link

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './extensions';
 export * from './files';
 export * from './url';
 export * from './theme';
+export * from './tab';

--- a/src/utils/tab.ts
+++ b/src/utils/tab.ts
@@ -1,0 +1,13 @@
+/**
+ * Forms the tab name for the browser from a label
+ * @param label workspace label, view name, etc. Defaults to empty string
+ * @returns "Ownly" if label is empty, otherwise "\<label\> - Ownly"
+ */
+export function formTabName(label: string = ''): string {
+  label = label.trim();
+
+  if (!label) {
+    return 'Ownly';
+  }
+  return `${label} - Ownly`;
+}

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import AboutComponent from '@/components/landing/AboutComponent.vue';
+import { formTabName } from '@/utils';
 import { onMounted } from 'vue';
 
 onMounted(() => {
   // Update tab name
-  document.title = 'About - Ownly';
+  document.title = formTabName('About');
 });
 </script>
 

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -79,7 +79,7 @@ async function refreshList() {
 
 onMounted(async () => {
   // Update tab name
-  document.title = 'Dashboard - Ownly';
+  document.title = utils.formTabName('Dashboard');
 
   await refreshList();
 

--- a/src/views/ProjectFileView.vue
+++ b/src/views/ProjectFileView.vue
@@ -163,14 +163,17 @@ async function create() {
     const wksp = await Workspace.setupOrRedir(router);
     if (!wksp) throw new Error('Workspace not found');
 
-    if (wksp.proj.active) return wksp.proj.active;
+    let newProj;
 
-    // No active project, try to get it from the URL
-    const projName = router.currentRoute.value.params.project as string;
-    if (!projName) throw new Error('No project name provided');
+    if (wksp.proj.active) newProj = wksp.proj.active;
+    else {
+      // No active project, try to get it from the URL
+      const projName = router.currentRoute.value.params.project as string;
+      if (!projName) throw new Error('No project name provided');
 
-    const newProj = await wksp.proj.get(projName);
-    await newProj.activate();
+      newProj = await wksp.proj.get(projName);
+      await newProj.activate();
+    }
 
     if (proj.value?.uuid !== newProj.uuid) await destroy();
     proj.value = newProj;

--- a/src/views/SpaceDiscussView.vue
+++ b/src/views/SpaceDiscussView.vue
@@ -149,6 +149,9 @@ async function setup() {
     wksp.value = await Workspace.setupOrRedir(router);
     if (!wksp.value) return;
 
+    // Update tab name
+    document.title = utils.formTabName(wksp.value.metadata.label);
+
     // Load the chat messages
     items.value = null;
     items.value = await wksp.value.chat.getMessages(channelName.value);

--- a/src/views/SpaceHomeView.vue
+++ b/src/views/SpaceHomeView.vue
@@ -41,6 +41,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 
 import { Workspace } from '@/services/workspace';
+import { formTabName } from '@/utils';
 
 const router = useRouter();
 
@@ -54,7 +55,7 @@ async function setup() {
   if (!wksp.value) return;
 
   // Update tab name
-  document.title = wksp.value.metadata.label + ' - Ownly';
+  document.title = formTabName(wksp.value.metadata.label);
 
   if (wksp.value.metadata.pendingSetup) {
     showWelcome.value = true;

--- a/src/views/SpaceProjectView.vue
+++ b/src/views/SpaceProjectView.vue
@@ -32,6 +32,7 @@ import { Workspace } from '@/services/workspace';
 import { Toast } from '@/utils/toast';
 
 import type { WorkspaceProj } from '@/services/workspace-proj';
+import { formTabName } from '@/utils';
 
 const route = useRoute();
 const router = useRouter();
@@ -49,6 +50,9 @@ async function setup() {
 
     proj.value = await wksp.proj.get(projName.value);
     if (!proj.value) return;
+
+    // Update tab name
+    document.title = formTabName(wksp.metadata.label);
 
     await proj.value.activate();
   } catch (err) {


### PR DESCRIPTION
- add a utility method to form tab name from a label
- code to update the browser tab when discuss, project, or file views are mounted. This updates the tab name even when the view is accessed by a URL

Extension to #65 
Fixes #66 