### PR TITLE
add a toggle to bypass cert lifetime in sync

### DIFF
--- a/ndn/app/app.go
+++ b/ndn/app/app.go
@@ -144,9 +144,9 @@ func (a *App) JsApi() js.Value {
 			return a.IsWorkspaceOwner(p[0].String())
 		}),
 
-		// get_workspace(name: string): Promise<WorkspaceAPI>;
+		// get_workspace(name: string, ignore: boolean): Promise<WorkspaceAPI>;
 		"get_workspace": jsutil.AsyncFunc(func(this js.Value, p []js.Value) (any, error) {
-			return a.GetWorkspace(p[0].String())
+			return a.GetWorkspace(p[0].String(), p[1].Bool())
 		}),
 	}
 

--- a/ndn/go.mod
+++ b/ndn/go.mod
@@ -2,7 +2,7 @@ module github.com/pulsejet/ownly/ndn
 
 go 1.23.4
 
-require github.com/named-data/ndnd v1.5.3-0.20250516053421-dc4c14533f50
+require github.com/named-data/ndnd v1.5.3-0.20250712020000-ed6bc2901834
 
 require (
 	github.com/cespare/xxhash v1.1.0 // indirect

--- a/ndn/go.sum
+++ b/ndn/go.sum
@@ -27,8 +27,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/named-data/ndnd v1.5.3-0.20250516053421-dc4c14533f50 h1:LzGeQKvr4PP7afaRI+5R97GMtQ8pjxMj8R+7XuzpSvo=
-github.com/named-data/ndnd v1.5.3-0.20250516053421-dc4c14533f50/go.mod h1:Pkal5FhOqapZs1bd6WalH5r86TmTD9zBeQwSQiX38zw=
+github.com/named-data/ndnd v1.5.3-0.20250712020000-ed6bc2901834 h1:345yvIm+37SFexV6ees8XK3T+3z3ubAK5z7TWVt5zB4=
+github.com/named-data/ndnd v1.5.3-0.20250712020000-ed6bc2901834/go.mod h1:UAaa210BjVOroqFs/9tDmXYfegVQQvj6yueqO27e68c=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=

--- a/src/components/home/CreateWorkspaceModal.vue
+++ b/src/components/home/CreateWorkspaceModal.vue
@@ -91,7 +91,7 @@ async function create() {
     }
 
     // Join the workspace with attempt to create
-    const finalName = await Workspace.join(label, fullName.value, true);
+    const finalName = await Workspace.join(label, fullName.value, true, false);
 
     emit('create', finalName);
     emit('close');

--- a/src/components/home/JoinWorkspaceModal.vue
+++ b/src/components/home/JoinWorkspaceModal.vue
@@ -93,7 +93,7 @@ async function join() {
     }
 
     // Join the workspace without attempting create
-    const finalName = await Workspace.join(label, name, false);
+    const finalName = await Workspace.join(label, name, false, false);
 
     emit('join', finalName);
     emit('close');

--- a/src/components/home/WorkspaceCard.vue
+++ b/src/components/home/WorkspaceCard.vue
@@ -25,10 +25,28 @@
         </button>
       </div>
 
-      <div class="content has-text-right">
-        <button class="button is-primary mr-2 is-small-caps soft-if-dark" @click="launch">
-          Launch Workspace
-        </button>
+      <div class="content">
+        <div class="field mb-3">
+          <div class="control">
+            <div class="field is-grouped is-grouped-left">
+              <div class="control">
+                <div class="toggle-switch" @click="toggleIgnoreValidity">
+                  <input type="checkbox" :checked="ignoreValidity" class="toggle-input" />
+                  <span class="toggle-slider" :class="{ active: ignoreValidity }"></span>
+                </div>
+              </div>
+              <div class="control">
+                <span class="is-size-7">{{ ignoreValidity ? 'Magic ON' : 'Magic OFF' }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="has-text-right">
+          <button class="button is-primary mr-2 is-small-caps soft-if-dark" @click="launch">
+            Launch Workspace
+          </button>
+        </div>
       </div>
     </div>
 
@@ -42,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, useTemplateRef } from 'vue';
+import { onMounted, ref, useTemplateRef } from 'vue';
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
@@ -56,6 +74,7 @@ import type { PropType } from 'vue';
 import type { IWkspStats } from '@/services/types';
 
 const showLeave = ref(false);
+const ignoreValidity = ref(false); // Default to off
 
 const props = defineProps({
   metadata: {
@@ -69,7 +88,41 @@ const emit = defineEmits(['open', 'leave']);
 const avatar = ref<string>(utils.makeAvatar(props.metadata.name ?? 'wksp', 'shapes'));
 const wkspMenu = useTemplateRef('wkspMenu');
 
-function launch() {
+onMounted(() => {
+  try {
+    // Initialize the toggle with the stored preference
+    ignoreValidity.value = props.metadata.ignore ?? false;
+    console.log('WorkspaceCard mounted:', props.metadata.name, 'ignore:', props.metadata.ignore);
+  } catch (err) {
+    console.error('Error mounting WorkspaceCard:', err);
+    ignoreValidity.value = false;
+  }
+});
+
+function toggleIgnoreValidity() {
+  ignoreValidity.value = !ignoreValidity.value;
+  updateIgnorePreference();
+}
+
+async function updateIgnorePreference() {
+  // Update the ignore preference in metadata when toggle changes
+  try {
+    const metadata = { ...props.metadata, ignore: ignoreValidity.value };
+    await _o.stats.put(metadata.name, metadata);
+  } catch (err) {
+    console.error('Failed to update ignore preference:', err);
+  }
+}
+
+async function launch() {
+  // Update metadata with current ignore preference before launching
+  try {
+    const metadata = { ...props.metadata, ignore: ignoreValidity.value };
+    await _o.stats.put(metadata.name, metadata);
+  } catch (err) {
+    console.error('Failed to update ignore preference before launch:', err);
+  }
+
   emit('open');
 
   // Take this chance to request persistent storage
@@ -89,5 +142,58 @@ function launch() {
 
 .media img {
   border-radius: 4px;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.toggle-input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  border-radius: 24px;
+  transition: 0.3s;
+
+  &:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    border-radius: 50%;
+    transition: 0.3s;
+  }
+
+  &.active {
+    background-color: #2196f3;
+
+    &:before {
+      transform: translateX(24px);
+    }
+  }
+}
+
+.toggle-switch:hover .toggle-slider {
+  background-color: #b3b3b3;
+
+  &.active {
+    background-color: #1976d2;
+  }
 }
 </style>

--- a/src/services/ndn.ts
+++ b/src/services/ndn.ts
@@ -39,7 +39,7 @@ interface NDNAPI {
   is_workspace_owner(wksp: string): Promise<boolean>;
 
   /** Get a Workspace API */
-  get_workspace(name: string): Promise<WorkspaceAPI>;
+  get_workspace(name: string, ignore: boolean): Promise<WorkspaceAPI>;
 }
 
 export interface WorkspaceAPI {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -5,6 +5,8 @@ export type IWkspStats = {
   name: string;
   /** Is the current user the owner */
   owner: boolean;
+  /** Workspace ignore certificate lifetime */
+  ignore: boolean;
   /** Workspace is pending initial setup */
   pendingSetup?: boolean;
   /** Last access time */

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -43,7 +43,7 @@ export class Workspace {
     await ndn.api.connect_testbed();
 
     // Set up client and ALO
-    const api = await ndn.api.get_workspace(metadata.name);
+    const api = await ndn.api.get_workspace(metadata.name, metadata.ignore);
     await api.start();
 
     // Create general SVS group
@@ -167,7 +167,7 @@ export class Workspace {
    * @param wksp Workspace name
    * @param create Create the workspace if it does not exist
    */
-  public static async join(label: string, wksp: string, create: boolean): Promise<string> {
+  public static async join(label: string, wksp: string, create: boolean, ignore: boolean): Promise<string> {
     const metadata = await _o.stats.get(wksp);
     if (metadata) throw new Error('You have already joined this workspace');
 
@@ -182,6 +182,7 @@ export class Workspace {
       label: label,
       name: finalName,
       owner: isOwner,
+      ignore: ignore,
       pendingSetup: create ? true : undefined,
     });
 


### PR DESCRIPTION
Only tested for two workspaces that suffer from this issue. If you toggle on (off by default) it should look like this, then subsequent SVS related logic (snapshot included) should apply ignoreValidity flag in validation. Better test it more before merging it?

<img width="400" height="300" alt="Screenshot 2025-07-11 at 8 53 18 PM" src="https://github.com/user-attachments/assets/cdd02411-e75f-4b06-a5ea-90beb10f59f2" />

This PR also updates ndnd version.