### PR TITLE
email conversion updated to single name component

### DIFF
--- a/src/components/InvitePeopleModal.vue
+++ b/src/components/InvitePeopleModal.vue
@@ -311,7 +311,7 @@ function addInvitee(invitee: string) {
     }
 
     // Convert email to NDN name
-    const ndnName = utils.convertEmailToNameLegacy(entry);
+    const ndnName = utils.convertEmailToName(entry);
 
     // Form profile
     new_profile = { name: ndnName, email: entry };
@@ -354,7 +354,7 @@ function addRequest(invitee: string) {
     }
 
     // Convert email to NDN name
-    const ndnName = utils.convertEmailToNameLegacy(entry);
+    const ndnName = utils.convertEmailToName(entry);
 
     // Form profile
     new_profile = { name: ndnName, email: entry };

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -16,12 +16,7 @@ export function convertEmailToName(email: string): string {
     throw new Error('Invalid email address');
   }
 
-  const parts = email.toLowerCase().split('@');
-  const user = parts[0];
-  const domain = parts[1];
-
-  // Technically @ is not allowed in URI, but NDNd can handle this
-  return `/${domain}/@${user}`;
+  return encodeURIComponent(email.toLowerCase());
 }
 
 export function convertEmailToNameLegacy(email: string): string {


### PR DESCRIPTION
Match the new testbed ndncert /ndn/<email> naming convention for invites